### PR TITLE
precondition for TTL in mongodb

### DIFF
--- a/backend/src/database/DbServices.js
+++ b/backend/src/database/DbServices.js
@@ -1004,7 +1004,7 @@ async function uploadBigJsonData(data, fileName) {
 			assert.ifError(error);
 		})
 		.on('finish', async () => {
-			console.log('Done! Uplaoded BigReport');
+			console.log('Done! Uploaded BigReport');
 			console.log('ObjectID: of Big Report: ', id);
 			return id;
 		});
@@ -1016,9 +1016,8 @@ async function uploadReport(reportResults) {
 	const db = dbConnection.getConnection();
 	const collection = await db.collection(ReportDataCollection);
 	fs.readFile(reportResults.reportOptions.jsonFile, 'utf8', async (err, data) => {
-		if(err)console.log(err)
-
-		const jReport = { jsonReport: data };
+		if (err) console.log(err);
+		const jReport = { jsonReport: data, created: new Date()};
 		const len = Buffer.byteLength(JSON.stringify(data));
 		if (len >= 16000000) {
 			try {


### PR DESCRIPTION
add creation date for reports as precondition to enable Time to Live (TTL) automatic delete in Mongo DB.

To enable TTL create an index on the date field. In the options enable TTL and choose an appropriate deletion time in seconds. 
